### PR TITLE
[CM-1343] Extend SyncRecord with SortInfo

### DIFF
--- a/Sources/YPersistence/Protocols/SyncRecord.swift
+++ b/Sources/YPersistence/Protocols/SyncRecord.swift
@@ -14,6 +14,8 @@ public protocol SyncRecord: DataRecord {
     var isUploaded: Bool { get set }
     /// Whether record is deleted or not
     var wasDeleted: Bool { get set }
+    /// A mult-attribute (column) sort
+    var sort: SortInfo? { get }
 
     /// The name of the attribute (database column) that represents the upload status
     static var isUploadedKey: String { get }
@@ -23,6 +25,8 @@ public protocol SyncRecord: DataRecord {
 
 /// Default implementation
 extension SyncRecord {
+    /// Returns `nil`
+    public var sort: SortInfo? { nil }
     /// Returns "isUploaded"
     public static var isUploadedKey: String { Constants.SyncRecord.isUploaded }
     /// Returns "wasDeleted"

--- a/Sources/YPersistence/Protocols/SyncRecord.swift
+++ b/Sources/YPersistence/Protocols/SyncRecord.swift
@@ -14,7 +14,7 @@ public protocol SyncRecord: DataRecord {
     var isUploaded: Bool { get set }
     /// Whether record is deleted or not
     var wasDeleted: Bool { get set }
-    /// A mult-attribute (column) sort
+    /// Optional sort order
     var sort: SortInfo? { get }
 
     /// The name of the attribute (database column) that represents the upload status
@@ -25,7 +25,7 @@ public protocol SyncRecord: DataRecord {
 
 /// Default implementation
 extension SyncRecord {
-    /// Returns `nil`
+    /// Returns `nil` (no sort order)
     public var sort: SortInfo? { nil }
     /// Returns "isUploaded"
     public static var isUploadedKey: String { Constants.SyncRecord.isUploaded }

--- a/Tests/YPersistenceTests/Protocols/SyncRecordTests.swift
+++ b/Tests/YPersistenceTests/Protocols/SyncRecordTests.swift
@@ -31,11 +31,34 @@ final class SyncRecordTests: XCTestCase {
         XCTAssertTrue(sut.wasDeleted)
         XCTAssertTrue(sut.isUploaded)
     }
+
+    func test_defaultSort_deliversNil() {
+        let sut = SyncRecordDefaultTest()
+        // Default should be nil
+        XCTAssertNil(sut.sort)
+    }
+    
+    func test_sort_deliversCorrectResult() {
+        let sut = SyncRecordTest()
+
+        let keys = ["Convenstional", "Digital"]
+        let ascending = Bool.random()
+        let columns = [
+            SortColumn(key: keys[0], ascending: ascending),
+            SortColumn(key: keys[1], ascending: !ascending)
+        ]
+
+        let expectedSortInfo = SortInfo(columns: columns)
+        sut.sort = expectedSortInfo
+
+        XCTAssertEqual(sut.sort, expectedSortInfo)
+    }
 }
 
 final class SyncRecordTest: NSObject { /* To conform to NSObjectProtocol*/
     var isUploaded: Bool = false
     var wasDeleted: Bool = false
+    var sort: SortInfo?
 
     static var isUploadedKey: String { "Uploading" }
     static var wasDeletedKey: String { "Deleted" }


### PR DESCRIPTION
## Introduction ##

Extend already present `SyncRecord` protocol to add `SortInfo`.
## Purpose ##

Adding a get property to `SyncRecord` with default implementation to nil. This provides user access to mult-attribute (column) sort.
## Scope ##

Added new optional property to `SyncRecord` protocol.
## Out of Scope ##

Any change in functionality.

## 📈 Coverage ##

##### Code #####

98.5%
<img width="1059" alt="Code coverage" src="https://user-images.githubusercontent.com/111066844/232703797-2d945138-e92d-4389-8f30-8b4e465e6dd8.png">

##### Documentation #####

100%
<img width="628" alt="Jazzy" src="https://user-images.githubusercontent.com/111066844/232704315-beb9fa0f-a163-4433-952e-3dcbb3a0ddbf.png">
